### PR TITLE
Add message about RI and SP sharing during transition to Rackspace.

### DIFF
--- a/docs/aws-accounts/transferring-existing-aws-accounts.rst
+++ b/docs/aws-accounts/transferring-existing-aws-accounts.rst
@@ -52,23 +52,9 @@ Note that transferring an existing AWS account to Rackspace does not count
 against the limit of new AWS accounts you are able to provision via the
 `Fanatical Support for AWS Control Panel <https://manage.rackspace.com/aws>`_.
 
-For AWS accounts that currently belong to a different AWS organization (i.e. 
-that are linked to another AWS account for consolidated billing purposes), 
-please note that the process for moving AWS accounts between organizations can 
-take more than one day to complete. During this process, Reserved Instances
-and Savings Plans that are normally shared with your AWS account from other
-AWS accounts in the original AWS organization will no longer be shared with
-the AWS account that you are moving to Rackspace unless and until those 
-sharing accounts move into the same AWS organization that your account is 
-moved to. Similarly, if your AWS account was previously sharing these 
-discounts with other AWS accounts in its original AWS organization, that 
-sharing may be disrupted or change in behavior during or after the account 
-transfer process. Although we are happy to raise a request on your behalf, 
-there is no guarantee that Amazon will provide any credit to cover the 
-increased costs that may result. Therefore, we recommend working closely 
-with Rackspace and/or Amazon to plan your account moves in a way that
-maximizes your ability to utilize these discount mechanisms during the 
-transition process.  
+Please note that Reserved Instance and Savings Plan sharing between AWS
+accounts may be disrupted during the account transition process. For details,
+please consult your Rackspace Onboarding Manager or Customer Success Manager.
 
 Minimum Account Requirements
 ----------------------------

--- a/docs/aws-accounts/transferring-existing-aws-accounts.rst
+++ b/docs/aws-accounts/transferring-existing-aws-accounts.rst
@@ -52,15 +52,31 @@ Note that transferring an existing AWS account to Rackspace does not count
 against the limit of new AWS accounts you are able to provision via the
 `Fanatical Support for AWS Control Panel <https://manage.rackspace.com/aws>`_.
 
+For AWS accounts that currently belong to a different AWS organization (i.e. 
+that are linked to another AWS account for consolidated billing purposes), 
+please note that the process for moving AWS accounts between organizations can 
+take more than one day to complete. During this process, Reserved Instances
+and Savings Plans that are normally shared with your AWS account from other
+AWS accounts in the original AWS organization will no longer be shared with
+the AWS account that you are moving to Rackspace unless and until those 
+sharing accounts move into the same AWS organization that your account is 
+moved to. Similarly, if your AWS account was previously sharing these 
+discounts with other AWS accounts in its original AWS organization, that 
+sharing may be disrupted or change in behavior during or after the account 
+transfer process. Although we are happy to raise a request on your behalf, 
+there is no guarantee that Amazon will provide any credit to cover the 
+increased costs that may result. Therefore, we recommend working closely 
+with Rackspace and/or Amazon to plan your account moves in a way that
+maximizes your ability to utilize these discount mechanisms during the 
+transition process.  
+
 Minimum Account Requirements
 ----------------------------
 
 In order for an existing AWS account to be transitioned to Rackspace, it
 must meet our minimum account requirements, which include:
 
-* `No access keys exist for the root account <https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html#root-password>`_
-* `No EC2 Classic <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-vpc.html>`_
-  in use
+* `No access keys exist for the root user of the AWS account <https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html#root-password>`_
 * The account is not consolidated under a payer account or serving as a
   payer account with linked child accounts
 


### PR DESCRIPTION
Add a message explaining that reserved instances and savings plan sharing may be disrupted during / after transition to Rackspace. Remove incorrect statement that EC2 classic is not permitted for account assumption. 