### PR TITLE
Add Redirect for moved user management page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms /docs/fanatical-support-aws/user-management-and-perms
+/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms/* /docs/fanatical-support-aws/user-management-and-perms/:splat 200

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms/ /docs/fanatical-support-aws/user-management-and-perms/ 301

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms/ /docs/fanatical-support-aws/user-management-and-perms/
+/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms /docs/fanatical-support-aws/user-management-and-perms

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms/ /docs/fanatical-support-aws/user-management-and-perms/ 301
+/docs/fanatical-support-aws/access-and-permissions/user-management-and-perms/ /docs/fanatical-support-aws/user-management-and-perms/


### PR DESCRIPTION
looks like the user management page was moved in this PR: https://github.com/rackerlabs/docs-aws/pull/102/files which broke application links to this page.  This redirect should fix the issue for other consumers who may be linked to the same page.
![2021-05-06_16-20-08](https://user-images.githubusercontent.com/35456401/117360547-ef629c80-ae86-11eb-8314-7eaa3946d801.png)

To prevent broken links in portals it may be beneficial to create redirects for all pages that are moved / removed.

followed instruction here for redirect: https://docs.netlify.com/routing/redirects/


